### PR TITLE
Make the yapp run optional; we check in the build products from it. W…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ LDEST = lib/Bio/KBase/KIDL
 all: $(LDEST)/typedoc.pm $(LDEST)/erdoc.pm bin
 
 $(LDEST)/typedoc.pm: typedoc.yp
-	yapp -o $(LDEST)/typedoc.pm typedoc.yp
+	-yapp -o $(LDEST)/typedoc.pm typedoc.yp
 
 $(LDEST)/erdoc.pm: erdoc.yp
-	yapp -o $(LDEST)/erdoc.pm erdoc.yp
+	-yapp -o $(LDEST)/erdoc.pm erdoc.yp
 
 what:
 	@echo $(BIN_PERL)


### PR DESCRIPTION
…in32 install doesn't have it in the build environment.